### PR TITLE
[Bug] Fixed broadcast ending report sent before finishing broadcasting. 

### DIFF
--- a/src/main/java/top/rongxiaoli/plugins/Broadcast/Broadcast.java
+++ b/src/main/java/top/rongxiaoli/plugins/Broadcast/Broadcast.java
@@ -99,8 +99,8 @@ public class Broadcast extends ArisuBotAbstractCompositeCommand {
         }
         executor.schedule(() -> {
             context.getSender().sendMessage("广播结束。");
+            isBroadcasting = false;
         }, delay + 100, TimeUnit.MILLISECONDS);
-        isBroadcasting = false;
         context.getSender().sendMessage("广播共发送了" + friendsList.size() + "个好友，共" + groupList.size() + "个群。");
 
     }


### PR DESCRIPTION
Closes #87 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 广播完成后，现在会向命令发送者发送一条延迟通知，表示广播已结束。

- **改进**
	- 优化了广播完成后的消息通知，使反馈更加简洁明了。
	- 提升了用户在广播过程结束时的体验反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->